### PR TITLE
Make devops essentials central to the wave - Add links to other wave artifacts from it

### DIFF
--- a/concepts/devops-essentials/index.md
+++ b/concepts/devops-essentials/index.md
@@ -83,7 +83,11 @@ As someone applying concepts from DevOps, you will work in a number of different
 
 ### Infrastructure as Code
 
-Infrastructure as Code (IaC) is typically a declarative method of managing infrastructure in a way that treats your infrastructure components, such as physical servers and virtual machines, similar to application code. Depending on the tool you choose, you can describe them using a markup language ([YAML](https://yaml.org/), [HCL](https://pkg.go.dev/github.com/hashicorp/hcl/v2), or [TOML](https://toml.io/en/)), or a more general-purpose language ([Python](https://www.python.org/), [Go](https://go.dev/), or [Java](https://www.java.com/en/)), which is then stored in version control allowing us to manage it in a repeatable and automated way. Infrastructure as code allows us to apply the same best practices and procedures we use when developing application code to our infrastructure. Configuration files can be tested and versioned and changes to infrastructure can be made using the same processes as code changes. If something goes wrong, we can roll back to the last stable version. This can help to reduce errors and improve reliability. Additionally, IaC makes it easier to scale and manage infrastructure, especially in dynamic environments where infrastructure needs to change frequently. Some of the tools you might use for provisioning infrastructure are [HashiCorp’s Terraform](https://www.terraform.io/), [AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/home.html), or [AWS CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/Welcome.html). 
+Infrastructure as Code (IaC) is typically a declarative method of managing infrastructure in a way that treats your infrastructure components, such as physical servers and virtual machines, similar to application code. Depending on the tool you choose, you can describe them using a markup language ([YAML](https://yaml.org/), [HCL](https://pkg.go.dev/github.com/hashicorp/hcl/v2), or [TOML](https://toml.io/en/)), or a more general-purpose language ([Python](https://www.python.org/), [Go](https://go.dev/), or [Java](https://www.java.com/en/)), which is then stored in version control allowing us to manage it in a repeatable and automated way. Infrastructure as code allows us to apply the same best practices and procedures we use when developing application code to our infrastructure. Configuration files can be tested and versioned and changes to infrastructure can be made using the same processes as code changes. If something goes wrong, we can roll back to the last stable version. This can help to reduce errors and improve reliability. Additionally, IaC makes it easier to scale and manage infrastructure, especially in dynamic environments where infrastructure needs to change frequently. Some of the tools you might use for provisioning infrastructure are [HashiCorp’s Terraform](https://www.terraform.io/), [AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/home.html), or [AWS CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/Welcome.html).
+
+See it in action: 
+* [Bootstrapping your Terraform automation with Amazon CodeCatalyst](../../tutorials/bootstrapping-terraform-automation-amazon-codecatalyst/)
+* [💡Improve your AWS CloudFormation Skills (all levels) with this workshop! ☁️](https://twitter.com/lindavivah/status/1606310817917554691)
 
 ### Configuration management
 
@@ -112,6 +116,8 @@ You’re likely to hear the terms "CI/CD" and "pipelines" a lot throughout your 
 These practices can help to improve the speed and quality of software development by allowing for fast feedback and reducing manual gates and time spent waiting. This can help to reduce the time required to deliver new features and improvements to users, and can make it easier to iterate and evolve software over time.
 
 Pipelines built using these concepts can apply to a number of things including application code, infrastructure code, security checks, and more. They can exist as a single pipeline, or possibly as multiple pipelines that are chained together. 
+
+See it in action: [Big Trucks, Jackie Chan movies, and millions of cardboard boxes: How Amazon Does DevOps in Real Life](../../posts/how-amazon-does-devops-in-real-life/)
 
 ### Logging
 


### PR DESCRIPTION
*** Do not merge without first talking with Seth ***

This is just a mock-up of a proposal.  We do not have to end up merging this.

I wanted to envision what it would take to make [DevOps Essentials](https://gamma-site.buildon.aws/concepts/devops-essentials) the "center" of the DevOps wave, and then link from it to the other wave assets
* I reviewed all the DevOps items that are in _completed_ state
* If it matched one of the topics in **DevOps Essentials**, I added a link in that topic section
* I did not include most short-form video, since most of these are about being pointers, not destinations
  * But you can see one exception where I included a short-form video that points to a workshop -- not sure if this works--opinions welcome
  * I did not include the Twitch live stream, as I could not cleanly match it to a topic
  * So far only two topics matched -- the unmatched topic can provide guidance on where we need more artifacts

Please review and leave comments here.

By submitting this pull request, I confirm I own this content, have permission to use each image included in this content, and that it will be released under the [CC BY-SA 4.0 SA License](/LICENSE).