### PR TITLE
fix tags in where-do-i-put-my-backups-in-the-cloud

### DIFF
--- a/posts/where-do-i-put-my-backups-in-the-cloud/index.md
+++ b/posts/where-do-i-put-my-backups-in-the-cloud/index.md
@@ -2,9 +2,9 @@
 title: "Where do I put my backups in the cloud?"
 description: "Information AWS users need to know about backups, and where they need to store them. Will cover considerations around in-Region, cross-Region, and cross-account backups"
 tags:
-    - backups
+    - backup
     - aws-backup
-    - resiliency
+    - resilience
     - disaster-recovery
     - aws
 authorGithubAlias: jmoran8888


### PR DESCRIPTION
`backup` and `aws-backup` are new tags.  I will add the new tags in a separate PR

**By submitting this pull request, I confirm I own this content, have permission to use each image included in this content, and that it will be released under the [CC BY-SA 4.0 SA License](/LICENSE).**
