### PR TITLE
Add showInHomeFeed attribute to templates

### DIFF
--- a/templates/essentials.md
+++ b/templates/essentials.md
@@ -10,6 +10,7 @@ tags:
 authorGithubAlias: githubAliasWithoutQuotes
 authorName: Name Surname (no quotes around)
 date: YYYY-MM-DD (expected publication date)
+showInHomeFeed: false
 ---
 
 <!-- Throughout this template there will be comments like these, please remove them before committing the first version of the content piece. -->
@@ -27,6 +28,7 @@ All frontmatter must be in [syntactically correct YAML](https://learnxinyminutes
 - `authorGithubAlias` - your GitHub username
 - `authorName` - how you want your name to display for the author credit of this post
 - `date` - date this post is published in `YYYY-MM-DD` format. This does not effect when your post goes live and is purely for display purposes.
+- `showInHomeFeed` - Set this to `true` if you want the post to be on the home and RSS feeds. 
 
 
 Introduction (1-2 paragraphs) to the topic. Describe how this topic practically impacts builders in real-world terms, describing how it fits into a development workflow. Briefly reference some of the key components of this broad topic -- components you'll break down in more detail in the post itself. Remember to keep the post to 8-12 subtopics (sections).

--- a/templates/foundational.md
+++ b/templates/foundational.md
@@ -10,6 +10,7 @@ tags:
 authorGithubAlias: githubAliasWithoutQuotes
 authorName: Name Surname (no quotes around)
 date: YYYY-MM-DD (expected publication date)
+showInHomeFeed: false
 ---
 
 <!-- Throughout this template there will be comments like these, please remove them before committing the first version of the content piece. -->
@@ -27,6 +28,7 @@ All frontmatter must be in [syntactically correct YAML](https://learnxinyminutes
 - `authorGithubAlias` - your GitHub username
 - `authorName` - how you want your name to display for the author credit of this post
 - `date` - date this post is published in `YYYY-MM-DD` format. This does not effect when your post goes live and is purely for display purposes.
+- `showInHomeFeed` - Set this to `true` if you want the post to be on the home and RSS feeds. 
 
 An introduction to the topic, limited to 100 words.
 

--- a/templates/post.md
+++ b/templates/post.md
@@ -8,6 +8,7 @@ tags:
 authorGithubAlias: githubAliasWithoutQuotes
 authorName: Name Surname (no quotes around)
 date: YYYY-MM-DD (expected publication date)
+showInHomeFeed: true
 ---
 
 <!-- Throughout this template there will be comments like these, please remove them before committing the first version of the content piece. -->
@@ -24,6 +25,7 @@ All frontmatter must be in [syntactically correct YAML](https://learnxinyminutes
 - `authorGithubAlias` - your GitHub username
 - `authorName` - how you want your name to display for the author credit of this post
 - `date` - date this post is published in `YYYY-MM-DD` format. This does not effect when your post goes live and is purely for display purposes.
+- `showInHomeFeed` - Set this to `false` if you don't want the post to be on the home and RSS feeds. 
 
 ## Header 2
 

--- a/templates/tutorial.md
+++ b/templates/tutorial.md
@@ -10,6 +10,7 @@ tags:
 authorGithubAlias: githubAliasWithoutQuotes
 authorName: Name Surname (no quotes around)
 date: YYYY-MM-DD (expected publication date)
+showInHomeFeed: false
 ---
 
 <!-- Throughout this template there will be comments like these, please remove them before committing the first version of the content piece. -->
@@ -27,6 +28,7 @@ All frontmatter must be in [syntactically correct YAML](https://learnxinyminutes
 - `authorGithubAlias` - your GitHub username
 - `authorName` - how you want your name to display for the author credit of this post
 - `date` - date this post is published in `YYYY-MM-DD` format. This does not effect when your post goes live and is purely for display purposes.
+- `showInHomeFeed` - Set this to `true` if you want the post to be part on home and RSS feeds. 
 
 Introduction paragraph to the topic. Describe a real world example to illustrate the problem the reader is facing. Explain why it's a problem. Offer the solution you'll be laying out in this post.
 


### PR DESCRIPTION
According to the [FAQ](https://github.com/build-on-aws/content/blob/main/FAQ.md#how-do-i-add-posts-to-the-home-page-feed), only posts in the `posts/` directory are automatically added to the home and RSS feeds. To make sure this isn't overlooked by authors, this PR adds the attribute, along with the respective default setting and a description text, to all templates.

# Content Pull Request Checklist

Please check to make sure your content submission meets the following requirements by adding an `x` between the brackets:

- [x] The title of this pull request reflects the title of my content.
- [x] I have reviewed the [Content Review Checklist](/content/blob/main/CONTENT_REVIEW_CHECKLIST.md).
- [x] This pull request contains one piece of content (post or page).

**Important: if you are submitting a PR to update existing content, please ensure you [sync'ed your fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) first before you created your branch.**

Is this pull request linked to a Content Proposal or Idea Suggestion Issue? If so, please link to it below using the number or full link.

**By submitting this pull request, I confirm I own this content, have permission to use each image included in this content, and that it will be released under the [CC BY-SA 4.0 SA License](/LICENSE).**
